### PR TITLE
fix: ignore heartbeat message during EventQL queires

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -212,6 +212,8 @@ final readonly class Client
 
         foreach (NdJson::readStream($response->getBody()) as $eventLine) {
             switch ($eventLine->type) {
+                case 'heartbeat':
+                    break;
                 case 'row':
                     $row = $eventLine->payload;
                     yield $row;


### PR DESCRIPTION
Ignores heartbeat intervals from long lasting EventQL queries